### PR TITLE
ユーザービリティ向上のためのスタイル修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,7 @@ h2 {
 	line-height: 1.8em;
 	background-color: white;
 	margin: .5em 0.2em;
+	cursor: pointer;
 }
 .place {
 }

--- a/index.html
+++ b/index.html
@@ -197,6 +197,7 @@ h2 {
 	margin-bottom: 1em;
 }
 .url > a {
+	display: block;
 	text-decoration: none;
 	color: black !important;
 }

--- a/index.html
+++ b/index.html
@@ -175,6 +175,10 @@ h2 {
 	padding: .2em 0em .5em 0em;
 	margin: 0;
 }
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
 .item {
 	background-color: #F5F5F5;
 	padding: 1em;
@@ -246,7 +250,7 @@ h2 {
 	<input type=text id=searchbox placeholder="検索する単語をご入力ください"><!--<button id=btnclear>クリア</button>-->
 </div>
 <div id="toptags" class=tags></div>
-<div id="main"></div>
+<div id="main" class="container"></div>
 
 <div id="src">
 Data: <a href=https://creativecommons.jp/sciencecommons/aboutcc0/>CC0</a> <a href=https://docs.google.com/spreadsheets/d/1IiHUk3D_b6e5BfqFG3ZBxQ8X-QVACdY7CeQeG6C7S1w/>企業などによる支援一覧</a><br>


### PR DESCRIPTION
## 最大幅
 PC 画面だとコンテンツの幅が広がりすぎてしまうので、最大幅を 1200px にしました。

### Before
![スクリーンショット 2020-03-09 18 52 19](https://user-images.githubusercontent.com/5207601/76201790-2ca5ad00-6237-11ea-9c2a-bd5be7650391.png)


### After
![スクリーンショット 2020-03-09 18 52 26](https://user-images.githubusercontent.com/5207601/76201802-2fa09d80-6237-11ea-9d7f-72e37b50bc54.png)

## リンク領域
「アクセスしてみる」ボタンのリンク領域がテキスト部分のみでだったので、ボタン全体をクリックできるようにしました。

### Before
![スクリーンショット 2020-03-09 18 57 26](https://user-images.githubusercontent.com/5207601/76202273-eac93680-6237-11ea-84fb-56a60bc3cd3f.png)

### After
![スクリーンショット 2020-03-09 18 57 44](https://user-images.githubusercontent.com/5207601/76202281-ed2b9080-6237-11ea-8744-dc61272ddc14.png)

## その他
- タグのカーソルスタイルをカーソルに修正しました。